### PR TITLE
Fix WGPU Backend and Animation Artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /target
-src/.env
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+src/.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,6 +1793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3494,6 +3500,7 @@ name = "rust-game"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "dotenvy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ default-run = "rust-game"
 
 [dependencies]
 bevy = "0.15.3"
+dotenvy = "0.15"
 
 # Enable a small amount of optimization in the dev profile.
 [profile.dev]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,33 @@
 use bevy::prelude::*;
+use bevy::render::settings::{WgpuSettings, RenderCreation, Backends};
+use bevy::render::RenderPlugin;
+use bevy::DefaultPlugins;
 
 const PLAYER_SPEED: f32 = 200.0;
 
 fn main() {
+    let wgpu_settings = WgpuSettings {
+        backends: Some(
+            if cfg!(target_os = "windows") {
+                Backends::DX12
+            } else if cfg!(target_os = "macos") {
+                Backends::METAL
+            } else {
+                Backends::VULKAN | Backends::GL
+            }
+        ),
+        ..default()
+    };
+    
     App::new()
-        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
+        .add_plugins(
+            DefaultPlugins
+                .set(ImagePlugin::default_nearest())
+                .set(RenderPlugin {
+                    render_creation: RenderCreation::Automatic(wgpu_settings),
+                    synchronous_pipeline_compilation: false,
+                }),
+        )
         .add_systems(Startup, setup)
         .add_systems(
             Update, (

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,15 @@
 use bevy::prelude::*;
-use bevy::render::settings::{WgpuSettings, RenderCreation, Backends};
-use bevy::render::RenderPlugin;
 use bevy::DefaultPlugins;
+use dotenvy::dotenv;
 
 const PLAYER_SPEED: f32 = 200.0;
 
 fn main() {
-    let wgpu_settings = WgpuSettings {
-        backends: Some(
-            if cfg!(target_os = "windows") {
-                Backends::DX12
-            } else if cfg!(target_os = "macos") {
-                Backends::METAL
-            } else {
-                Backends::VULKAN | Backends::GL
-            }
-        ),
-        ..default()
-    };
+    // To explicitly set a graphics backend, create an .env file with WGPU_BACKEND= dx12 (windows), metal (macos), vulkan (linux)
+    dotenv().ok();
     
     App::new()
-        .add_plugins(
-            DefaultPlugins
-                .set(ImagePlugin::default_nearest())
-                .set(RenderPlugin {
-                    render_creation: RenderCreation::Automatic(wgpu_settings),
-                    synchronous_pipeline_compilation: false,
-                }),
-        )
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_systems(Startup, setup)
         .add_systems(
             Update, (


### PR DESCRIPTION
- found issue with extra pixels during animation
    - default_nearest() was selecting pixels of neighbouring sprites
- main() runs .env file with specified graphics backend to avoid GPU driver issues
    - if no .env file, default backend is used for that OS