### PR TITLE
use multicast instead of broadcast

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,11 +1,18 @@
 use std::io::{self, Write, Read};
 use std::net::{TcpStream, UdpSocket};
+use std::net::Ipv4Addr;
 
 use rust_game::DISCOVERY_PORT;
 use rust_game::ECHO_PORT;
+use rust_game::MULTICAST_IP;
 
 fn discover() -> std::io::Result<Option<String>> {
     let socket = UdpSocket::bind(format!("0.0.0.0:{}", DISCOVERY_PORT))?;
+    
+    socket.join_multicast_v4(
+        &MULTICAST_IP.parse().unwrap(),
+        &Ipv4Addr::UNSPECIFIED,
+    )?;
     let mut buf = [0; 1024];
     
     loop {

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -4,6 +4,7 @@ use std::net::{TcpListener, TcpStream, UdpSocket};
 
 use rust_game::DISCOVERY_PORT;
 use rust_game::ECHO_PORT;
+use rust_game::MULTICAST_IP;
 
 fn handle_client(mut stream: TcpStream) {
     let mut buffer = [0; 512];
@@ -35,10 +36,9 @@ fn broadcast(socket: &UdpSocket) -> std::io::Result<()> {
     let message_bytes = message.as_bytes();
 
     loop {
-        socket.send_to(message_bytes, format!("255.255.255.255:{}", DISCOVERY_PORT))?;
-        thread::sleep(Duration::from_secs(2)); // broadcast every 2s
+        socket.send_to(message_bytes, format!("{}:{}", MULTICAST_IP, DISCOVERY_PORT))?;
+        thread::sleep(Duration::from_secs(2));
     }
-    // todo: cancel when received a connection
 }
 
 fn main() -> std::io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub const DISCOVERY_PORT: &str = "34254";
 pub const ECHO_PORT: &str = "7878";
+pub const MULTICAST_IP: &str = "239.255.42.78";


### PR DESCRIPTION
**Note: only tested on macOS. Can you please see if this is a breaking change for Windows?**

## Changes
- Investigated issue with macOS UDP broadcast. Turns out something at the OS level was filtering out broadcast packets.
- Did some research to see that the "modern" way to do this is to use a multicast group; this way we only broadcast our discovery message to consenting listeners in our so-called multicast group
- This fixes the issue with the OS packet filtering.
- Refactor exiting system to use new multicast instead of deprecated UDP broadcast

## Todo
- Right now, the multicast group IP is hard-coded. This _should_ be fine, as we only use this address for a short time, so the likelihood we run into traffic conflicts on this address is unlikely. However, in the future it would be nice to listen on the address for some time, and check if the chosen multicast address is already in use before hijacking it.
- Refactor into existing game system